### PR TITLE
Delegation, import correction and platform-dependence fixes

### DIFF
--- a/src/main/java/jce/codemanipulation/ecore/EcoreImportManipulator.java
+++ b/src/main/java/jce/codemanipulation/ecore/EcoreImportManipulator.java
@@ -1,9 +1,11 @@
 package jce.codemanipulation.ecore;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IImportDeclaration;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
@@ -64,10 +66,22 @@ public class EcoreImportManipulator extends AbstractCodeManipulator {
         String interfaceName = getPackageMemberName(ecoreInterface);
         if (importDeclaration.getElementName().equals(interfaceName)) {
             String typeName = nameUtil.cutFirstSegment(importDeclaration.getElementName());
-            ASTVisitor visitor = new TypeManipulationVisitor(typeName);
-            ASTUtil.applyVisitorModifications(ecoreInterface, visitor, monitor);
+            addQualifiedNamesToTypeReferences(ecoreInterface, typeName);
         }
     }
+
+    /**
+     * Makes all type references to the type with the given name in the given {@link ICompilationUnit} explicit
+     * using qualified names.
+     * @param unit is the {@link ICompilationUnit} to manipulate.
+     * @param typeName is the name of the type to make references to explicit.
+     * @throws JavaModelException if there are problems with the Java model.
+     */
+	private void addQualifiedNamesToTypeReferences(ICompilationUnit unit, String typeName)
+			throws JavaModelException {
+		ASTVisitor visitor = new TypeManipulationVisitor(typeName);
+		ASTUtil.applyVisitorModifications(unit, visitor, monitor);
+	}
 
     /**
      * Returns the name of the Ecore interface of an Ecore implementation class name. E.g. returns "model.Main" when
@@ -99,6 +113,27 @@ public class EcoreImportManipulator extends AbstractCodeManipulator {
      */
     private boolean isEcoreImplementationName(String typeName) {
         return nameUtil.getLastSegment(nameUtil.cutLastSegment(typeName)).equals("impl") && typeName.endsWith("Impl");
+    }
+
+    /**
+     * Checks and returns whether an {@link ICompilationUnit} is the representation of an Ecore interface.
+     */
+    private boolean isEcoreInterface(ICompilationUnit unit) throws JavaModelException {
+        String typeName = nameUtil.cutFirstSegment(getPackageMemberName(unit));
+        EClass potentialEClass = MetamodelSearcher.findEClass(typeName, metamodel.getRoot());
+        return potentialEClass != null && potentialEClass.isInterface();
+    }
+
+    /**
+     * Checks and returns whether an {@link ICompilationUnit} is the representation of an interface of an Ecore
+     * implementation class.
+     */
+    private boolean isInterfaceOfEcoreClass(ICompilationUnit unit) throws JavaModelException {
+        String typeName = nameUtil.cutFirstSegment(getPackageMemberName(unit));
+        EClass potentialEClass = MetamodelSearcher.findEClass(typeName, metamodel.getRoot());
+        // Ensure that the class is not the representation of an Ecore interface but only an interface of an
+        // implementation class
+        return potentialEClass != null && !potentialEClass.isInterface();
     }
 
     /**
@@ -156,19 +191,63 @@ public class EcoreImportManipulator extends AbstractCodeManipulator {
     }
 
     /**
+     * Changes the imports of a compilation unit and its Ecore interface if it is an Ecore implementation class and
+     * the imports of types in the same package if it is an Ecore interface. The super interface declarations of the
+     * classes are retained, while the import declarations of the Ecore type are changed to the relating types of
+     * the origin code.
+     * @param unit is the {@link ICompilationUnit}.
+     * @throws JavaModelException if there are problems with the Java model.
+     */
+    @Override
+    protected void manipulate(ICompilationUnit unit) throws JavaModelException {
+        manipulateEcoreClass(unit);
+        manipulateEcoreInterface(unit);
+    }
+
+    /**
+     * Changes the imports in the same package of a compilation unit if it is an Ecore interface. The
+     * super interface declarations of the classes are retained, while the import declarations of the Ecore type are
+     * changed to the relating types of the origin code, which are not represented as imports, as the Ecore types of the
+     * interfaces reside in the same package.
+     * @param unit is the {@link ICompilationUnit}.
+     * @throws JavaModelException if there are problems with the Java model.
+     */
+	private void manipulateEcoreInterface(ICompilationUnit unit) throws JavaModelException {
+		if (isEcoreInterface(unit)) {
+			retainInterface(unit); // retain the super interface of the interface
+			ICompilationUnit[] unitsInSamePackage = ((IPackageFragment) unit.getParent()).getCompilationUnits();
+			// Add explicit import for types in same package
+			for (ICompilationUnit samePackageUnit : unitsInSamePackage) {
+				if (isEcoreInterface(samePackageUnit) || isInterfaceOfEcoreClass(samePackageUnit)) {
+					String samePackageUnitQualifiedName = nameUtil.cutFirstSegment(getPackageMemberName(samePackageUnit));
+					ImportRewrite explicitSamePackageImportRewrite = ImportRewrite.create(unit, true);
+					explicitSamePackageImportRewrite.addImport(samePackageUnitQualifiedName);
+					ASTUtil.applyImportRewrite(unit, explicitSamePackageImportRewrite, monitor);
+					// Fix imports of type with same name
+					if (getPackageMemberName(samePackageUnit).equals(getPackageMemberName(unit)) ) {
+						addQualifiedNamesToTypeReferences(unit, samePackageUnitQualifiedName);
+					}
+				}
+			}
+			// Change imports in same package to those of original classes
+			rewriteImports(unit, unit);
+        }
+	}
+
+	/**
      * Changes the imports of a compilation unit and its Ecore interface if it is an Ecore implementation class. The
      * super interface declarations of the classes are retained, while the import declarations of the Ecore type are
      * changed to the relating types of the origin code.
      * @param unit is the {@link ICompilationUnit}.
      * @throws JavaModelException if there are problems with the Java model.
      */
-    @Override
-    protected void manipulate(ICompilationUnit unit) throws JavaModelException {
-        if (isEcoreImplementation(unit)) { // if is ecore implementation class of an EClass
+	private void manipulateEcoreClass(ICompilationUnit unit) throws JavaModelException {
+		if (isEcoreImplementation(unit)) { // if is ecore implementation class of an EClass
             ICompilationUnit ecoreInterface = findEcoreInterface(unit); // get the correlating ecore interface
             retainInterface(unit); // retain the super interfaces of both
             retainInterface(ecoreInterface);
             rewriteImports(unit, ecoreInterface);
         }
-    }
+	}
+
 }

--- a/src/main/java/jce/codemanipulation/ecore/InterfaceRetentionVisitor.java
+++ b/src/main/java/jce/codemanipulation/ecore/InterfaceRetentionVisitor.java
@@ -79,7 +79,7 @@ public class InterfaceRetentionVisitor extends ASTVisitor {
     private String getName(SimpleType type) {
         String typeName = type.getName().getFullyQualifiedName();
         for (IImportDeclaration declaration : imports) {
-            if (declaration.getElementName().endsWith(typeName)) {
+            if (declaration.getElementName().endsWith("." + typeName)) {
                 return declaration.getElementName();
             }
         }

--- a/src/main/java/jce/generators/GenModelGenerator.java
+++ b/src/main/java/jce/generators/GenModelGenerator.java
@@ -36,7 +36,8 @@ import jce.util.ResourceRefresher;
  */
 public class GenModelGenerator {
     private static final Logger logger = LogManager.getLogger(GenModelGenerator.class.getName());
-    private static final char SLASH = File.separatorChar;
+    private static final char SYSTEM_DEPENDENT_SEPARATOR = File.separatorChar;
+    private static final char SYSTEM_INDEPENDENT_SEPARATOR = '/';
     private final GenJDKLevel complianceLevel;
     private final String importerID;
     private final EcorificationProperties properties;
@@ -80,13 +81,13 @@ public class GenModelGenerator {
      */
     public GenModel generate(GeneratedEcoreMetamodel metamodel) {
         if (metamodel.isSaved()) {
-            PathHelper pathHelper = new PathHelper(SLASH);
+            PathHelper pathHelper = new PathHelper(SYSTEM_DEPENDENT_SEPARATOR);
             SavingInformation information = metamodel.getSavingInformation();
             String modelName = information.getFileName();
             String modelPath = information.getFilePath();
-            String projectName = SLASH + pathHelper.getLastSegment(pathHelper.cutLastSegment(modelPath));
+            String projectName = SYSTEM_INDEPENDENT_SEPARATOR + pathHelper.getLastSegment(pathHelper.cutLastSegment(modelPath));
             GenModel genModel = GenModelFactory.eINSTANCE.createGenModel();
-            genModel.setModelDirectory(projectName + File.separator + properties.get(SOURCE_FOLDER));
+            genModel.setModelDirectory(projectName + SYSTEM_INDEPENDENT_SEPARATOR + properties.get(SOURCE_FOLDER));
             genModel.setModelPluginID(projectName.substring(1));
             genModel.setModelName(modelName);
             genModel.setRootExtendsClass(rootExtendsClass);


### PR DESCRIPTION
This PR provides the follwing fixes:
- Platform depencency: Model paths in the GenModel use generic path separators. The implementation used platform-specific separators before.
- Delegation in wrapper classes: The delegation was performed to an interface of an EClass, which only provides the `EObject` interface, but also those methods of `InternalEObject` have to be delegated. Therefore, in the uppermost class of an inheritance hierarchy (analogously to the existing delegation) the instance is now additionally saved as an `InternalEObject` (which all Ecoreimplementation classes are) and the new `DelegateExcept` annotation is used to delegate only classes of the `InternalEObject` interface to that instance.
- Types with same suffix: If the name of a super interface of an Ecore implementation class is the suffix of another type, sometimes the wrong type was selected as only the suffix was matched to replace the super interface name with the fully qualified one (e.g. `IType` when the EClass is named `Type`). This changed the inheritance hierarchy. Now the last separator is also matched to ensure that the full name is equals and not just a suffic.
- Imports of types in same package: In Ecore interfaces and Ecore implementation class interfaces imports were not correctly changes to those of the original classes. For Ecore interfaces, this was generally the case. For both this was the case for those types that are placed in the same package, because they are not present in import declarations as they are implicitly imported and thus are not changed in the `EcoreImportManipulator`. Now explicit imports for types in the same package are created and replaced with those to the original classes like for other imports as well. Also self imports are correctly handled by replacing all the types of the parameters and return types.