### PR TITLE
Original factory init method correction

### DIFF
--- a/src/main/java/jce/codemanipulation/ecore/AbstractFactoryRenamer.java
+++ b/src/main/java/jce/codemanipulation/ecore/AbstractFactoryRenamer.java
@@ -101,9 +101,20 @@ public abstract class AbstractFactoryRenamer extends AbstractCodeManipulator {
         return MetamodelSearcher.findEClass(modelName, metamodel.getRoot()) != null; // search metamodel counterpart
     }
 
+    /**
+     * Returns whether the given {@link ICompilationUnit} is an Ecore factory and not the root factory,
+     * so that it has to be updated
+     * @param unit the {@link CompilationUnit} to check.
+     * @return true if factory is relevant for modifications
+     * @throws JavaModelException  if there is a problem with the JDT API.
+     */
+    protected final boolean isRelevantEcoreFactoryClassifier(ICompilationUnit unit) throws JavaModelException {
+        return isEcoreFactory(unit) && !isRootFactory(unit);
+    }
+
     @Override
-    protected final void manipulate(ICompilationUnit unit) throws JavaModelException {
-        if (isEcoreFactory(unit) && !isRootFactory(unit)) {
+    protected void manipulate(ICompilationUnit unit) throws JavaModelException {
+        if (isRelevantEcoreFactoryClassifier(unit)) {
             String name = unit.getElementName();
             String newName = nameUtil.cutLastSegment(name) + properties.get(FACTORY_SUFFIX); // new name of class
             newName = nameUtil.append(newName, nameUtil.getLastSegment(name)); // add file extension

--- a/src/main/java/jce/codemanipulation/ecore/FactoryImplementationRenamer.xtend
+++ b/src/main/java/jce/codemanipulation/ecore/FactoryImplementationRenamer.xtend
@@ -6,10 +6,12 @@ import jce.util.PathHelper
 import org.eclipse.jdt.core.JavaModelException
 
 import static extension jce.util.PathHelper.capitalize
+import jce.util.jdt.ASTUtil
+import org.eclipse.jdt.core.ICompilationUnit
 
 /**
  * Code manipulator that renames the original factory implementation classes.
- * @author Timur Saglam
+ * @author Timur Saglam, Heiko Klare
  */
 class FactoryImplementationRenamer extends AbstractFactoryRenamer {
 	extension PathHelper nameUtil = super.nameUtil
@@ -36,4 +38,19 @@ class FactoryImplementationRenamer extends AbstractFactoryRenamer {
 		}
 		return false; // Does not have Ecore implementation name and package
 	}
+
+	/**
+	 * Removes the namespace URI-based factory determination in originally generated factories,
+	 * because they are only used internally and not globally registered.
+	 * Afterwards applies the general manipulation logic of
+	 * {@link AbstractFactoryRenamer#manipulate(ICompilationUnit) AbstractFactoryRenamer}.
+	 * @param unit the {@link ICompilationUnit} to manipulate
+	 */
+	override manipulate(ICompilationUnit unit) {
+		if (isRelevantEcoreFactoryClassifier(unit)) {
+			ASTUtil.applyVisitorModifications(unit, new FactoryInitMethodCorrectionVisitor(), monitor);
+		}
+		super.manipulate(unit);
+	}
+
 }

--- a/src/main/java/jce/codemanipulation/ecore/FactoryInitMethodCorrectionVisitor.xtend
+++ b/src/main/java/jce/codemanipulation/ecore/FactoryInitMethodCorrectionVisitor.xtend
@@ -1,0 +1,24 @@
+package jce.codemanipulation.ecore
+
+import org.eclipse.jdt.core.dom.ASTVisitor
+import org.eclipse.jdt.core.dom.MethodDeclaration
+import org.eclipse.jdt.core.dom.ReturnStatement
+
+/**
+ * {@link ASTVisitor} class that manipulates the init method of original Ecore factories in the generated code.
+ * @author Heiko Klare
+ */
+class FactoryInitMethodCorrectionVisitor extends ASTVisitor {
+	private static final String FACTORY_INIT_METHOD_NAME = "init";
+	
+	/**
+	 * Removes the namespace-URI-based factory determination logic from the original Ecore factories, 
+	 * because they are are only used internally and are not registered globally. 
+	 */
+	public override boolean visit(MethodDeclaration node) {
+		if (node.name.toString == FACTORY_INIT_METHOD_NAME) {
+			node.body.statements.removeIf[!(it instanceof ReturnStatement)]
+		}
+		return true;
+	}
+}

--- a/src/main/java/jce/util/jdt/ASTUtil.xtend
+++ b/src/main/java/jce/util/jdt/ASTUtil.xtend
@@ -84,6 +84,8 @@ final class ASTUtil {
 		parsedUnit.accept(visitor)
 		var TextEdit edits = parsedUnit.rewrite(new Document(unit.source), null)
 		applyTextEdit(edits, unit, monitor)
+		unit.commitWorkingCopy(true, monitor);
+		unit.discardWorkingCopy();
 	}
 
 	/** 


### PR DESCRIPTION
This pull request introduces a modification mechanism for the `init` method of the originally generated Ecore factories. They originally utilize the namespace URI to retrieve the factory from the global registry, but these generated factories are only to be used internally and not registered globally, which is why this retrieval fails. The modification logic removes that registry lookup and just creates a new factory.