### PR TITLE
ADD: Make extension of model files configurable

### DIFF
--- a/src/main/java/jce/generators/GenModelGenerator.java
+++ b/src/main/java/jce/generators/GenModelGenerator.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.codegen.ecore.genmodel.GenJDKLevel;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModel;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModelFactory;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModelPackage;
+import org.eclipse.emf.codegen.ecore.genmodel.GenPackage;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
@@ -26,6 +27,7 @@ import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
 import eme.generator.GeneratedEcoreMetamodel;
 import eme.generator.saving.SavingInformation;
 import jce.properties.EcorificationProperties;
+import jce.properties.TextProperty;
 import jce.util.PathHelper;
 import jce.util.ResourceRefresher;
 
@@ -97,6 +99,10 @@ public class GenModelGenerator {
             genModel.setImportOrganizing(true);
             genModel.getForeignModel().add(modelName + ".ecore");
             genModel.initialize(Collections.singleton(metamodel.getRoot()));
+            GenPackage rootPackage = genModel.getGenPackages().get(0);
+            if (rootPackage != null) {
+            	rootPackage.setFileExtensions(properties.get(TextProperty.MODEL_FILE_EXTENSION));
+            }
             URI uri = saveGenModel(genModel, modelPath, modelName); // IMPORTANT: first save the GenModel
             return loadGenModel(uri); // and then LOAD IT AGAIN (prevents package URI exception)!
         }

--- a/src/main/java/jce/properties/TextProperty.java
+++ b/src/main/java/jce/properties/TextProperty.java
@@ -15,8 +15,9 @@ public enum TextProperty implements ITextProperty {
     PROJECT_SUFFIX("ProjectSuffix", "Ecorified"),
     SOURCE_FOLDER("SourceFolder", "src"),
     ROOT_CONTAINER("RootContainerName", "RootContainer"),
-    FACTORY_SUFFIX("OriginalFactorySuffix", "Old");
-
+    FACTORY_SUFFIX("OriginalFactorySuffix", "Old"),
+    MODEL_FILE_EXTENSION("ModelFileExtension", "ecorified");
+	
     private final String defaultValue;
     private final String key;
 

--- a/user.properties
+++ b/user.properties
@@ -6,6 +6,7 @@ SourceFolder=src
 ProjectSuffix=Ecorified
 RootContainerName=RootContainer
 OriginalFactorySuffix=Old
+ModelFileExtension=ecorified
 #PACKAGES:
 EcorePackageName=ecore
 WrapperPackageName=unification


### PR DESCRIPTION
This pull request adds a property to configure the file extension used by models that instantiate the extracted metamodel.