### PR TITLE
Package class correction

### DIFF
--- a/src/main/java/jce/JavaCodeEcorification.java
+++ b/src/main/java/jce/JavaCodeEcorification.java
@@ -20,6 +20,7 @@ import jce.codemanipulation.ImportOrganizer;
 import jce.codemanipulation.ecore.EcoreImportManipulator;
 import jce.codemanipulation.ecore.FactoryImplementationRenamer;
 import jce.codemanipulation.ecore.FactoryRenamer;
+import jce.codemanipulation.ecore.PackageImplFactoryCorrector;
 import jce.codemanipulation.origin.ClassExposer;
 import jce.codemanipulation.origin.DefaultConstructorGenerator;
 import jce.codemanipulation.origin.FieldEncapsulator;
@@ -99,6 +100,7 @@ public class JavaCodeEcorification {
         new FactoryImplementationRenamer(metamodel, properties).manipulate(project);
         new DefaultConstructorGenerator(properties).manipulate(project); // TODO (HIGH) Is this too early?
         new EcoreFactoryGenerator(properties).buildFactories(metamodel, project);
+        new PackageImplFactoryCorrector(metamodel, properties).manipulate(project);
         new ClassExposer(properties).manipulate(project);
     }
 

--- a/src/main/java/jce/codemanipulation/ecore/PackageImplFactoryCorrectionVisitor.xtend
+++ b/src/main/java/jce/codemanipulation/ecore/PackageImplFactoryCorrectionVisitor.xtend
@@ -1,0 +1,109 @@
+package jce.codemanipulation.ecore
+
+import org.eclipse.jdt.core.dom.ASTVisitor
+import org.eclipse.jdt.core.ICompilationUnit
+import jce.properties.EcorificationProperties
+import jce.properties.TextProperty
+import org.eclipse.jdt.core.dom.SimpleType
+import org.eclipse.jdt.core.dom.MethodDeclaration
+import org.eclipse.jdt.core.dom.CastExpression
+import org.eclipse.jdt.core.dom.AST
+import org.eclipse.jdt.core.dom.Type
+import org.eclipse.jdt.core.dom.QualifiedName
+import org.eclipse.jdt.core.dom.ImportDeclaration
+import jce.util.PathHelper
+
+/**
+ * This visitors replaces all references to the factory class within a package interface or
+ * package implementation class to the newly generated factory. The old factory has a suffix,
+ * which is replaced in imports, member references, return types and casts.
+ * 
+ * @author Heiko Klare
+ */
+class PackageImplFactoryCorrectionVisitor extends ASTVisitor {
+	public static val PACKAGE_IMPL_SUFFIX = "PackageImpl";
+	public static val PACKAGE_SUFFIX = "Package";
+	private static val FACTORY_SUFFIX = "Factory";
+	private val String factoryName;
+	private val ICompilationUnit compilationUnit;
+	private val EcorificationProperties properties;
+	private val PathHelper pathHelper;
+	
+	new(ICompilationUnit compilationUnit, EcorificationProperties properties) {
+		this.properties = properties;
+		this.compilationUnit = compilationUnit;
+		this.pathHelper = new PathHelper(".")
+		val compilationUnitName = pathHelper.cutLastSegment(compilationUnit.elementName);
+		this.factoryName = if (compilationUnit.elementName.contains(PACKAGE_IMPL_SUFFIX)) {
+			compilationUnitName.substring(0, compilationUnitName.length - PACKAGE_IMPL_SUFFIX.length) + FACTORY_SUFFIX
+		} else {
+			compilationUnitName.substring(0, compilationUnitName.length - PACKAGE_SUFFIX.length) + FACTORY_SUFFIX
+		}
+	}
+	
+	/**
+	 * Corrects the import declaration of the old factory to import the newly generated one instead. 
+	 */
+	override visit(ImportDeclaration node) {
+		if (node.name.fullyQualifiedName.contains(factoryName)) {
+			node.name = node.AST.newName(node.name.fullyQualifiedName.removeOldFactorySuffix);
+		}
+		return true;
+	}
+	
+	/**
+	 * Corrects references to static variables of the factory class, especially to the <code>eINSTANCE</code> field.
+	 */
+	override visit(QualifiedName node) {
+		if (node.qualifier.fullyQualifiedName.contains(factoryName)) {
+			node.qualifier = node.AST.newSimpleName(node.qualifier.fullyQualifiedName.removeOldFactorySuffix);
+		}
+		return true;
+	}
+
+	/**
+	 * Corrects the return type of methods to use the newly generated factory type. This is especially necessary
+	 * for the factory getter method.
+	 */
+	override visit(MethodDeclaration node) {
+		val newType = node.returnType2.modifyType(node.AST);
+		if (newType !== null) {
+			node.returnType2 = newType;
+		}
+		 
+		return true;
+	}
+
+	/**
+	 * Corrects casts to the factory class to use the newly generated factory type. This is especially necessary
+	 * within the factory getter method.
+	 */
+	override visit(CastExpression node) {
+		val newType = node.type.modifyType(node.AST);
+		if (newType !== null) {
+			node.type = newType;
+		}
+
+		return true;
+	}
+	
+	/**
+	 * Returns a type referencing the newly generated factory given the {@link SimpleType} of the old factory.
+	 * Otherwise <code>null</code> is returned.
+	 */
+	private def Type modifyType(Type type, AST ast) {
+		if (type instanceof SimpleType) {
+			if (type.name.fullyQualifiedName.contains(factoryName)) {
+				return ast.newSimpleType(ast.newSimpleName(type.name.fullyQualifiedName.removeOldFactorySuffix));
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * Removes the old factory suffic from the given factory name.
+	 */
+	private def String removeOldFactorySuffix(String oldFactoryName) {
+		return oldFactoryName.replace(FACTORY_SUFFIX + properties.get(TextProperty.FACTORY_SUFFIX), FACTORY_SUFFIX);
+	}
+}

--- a/src/main/java/jce/codemanipulation/ecore/PackageImplFactoryCorrector.xtend
+++ b/src/main/java/jce/codemanipulation/ecore/PackageImplFactoryCorrector.xtend
@@ -1,0 +1,51 @@
+package jce.codemanipulation.ecore
+
+import jce.codemanipulation.AbstractCodeManipulator
+import org.eclipse.jdt.core.ICompilationUnit
+import org.eclipse.jdt.core.JavaModelException
+import jce.properties.EcorificationProperties
+import jce.properties.TextProperty
+import jce.util.jdt.ASTUtil
+import jce.util.PathHelper
+import eme.generator.GeneratedEcoreMetamodel
+import static extension jce.util.EPackageUtil.*;
+
+/**
+ * Code manipulator that correct references to factories in the package classes generated
+ * from the Ecore metamodel. Due to the replacement of factories, the new instead of the old
+ * ones have to be referenced.
+ * 
+ * @author Heiko Klare
+ */
+class PackageImplFactoryCorrector extends AbstractCodeManipulator {
+	private val extension PathHelper pathHelper;
+	private val GeneratedEcoreMetamodel metamodel;
+	
+	new(GeneratedEcoreMetamodel metamodel, EcorificationProperties properties) {
+		super(properties.get(TextProperty.ECORE_PACKAGE), properties)
+		this.metamodel = metamodel;
+		this.pathHelper = new PathHelper(".");
+	}
+
+	override protected manipulate(ICompilationUnit unit) throws JavaModelException {
+		val unitName = getPackageMemberName(unit);
+		val String packageName =
+			if (unitName.endsWith(PackageImplFactoryCorrectionVisitor.PACKAGE_IMPL_SUFFIX)) {
+				unitName.parent.parent;
+			} else if (unitName.endsWith(PackageImplFactoryCorrectionVisitor.PACKAGE_SUFFIX)) {
+				unitName.parent;
+			} else {
+				return;
+			}
+		val package = metamodel.root.findPackage(packageName);
+		// All packages containing classes got new factories that have to be referenced in package classes
+		if (!package.classNames.empty) {
+			val visitor = new PackageImplFactoryCorrectionVisitor(unit, properties);
+			ASTUtil.applyVisitorModifications(unit, visitor, monitor);
+			unit.commitWorkingCopy(true, monitor);
+			unit.discardWorkingCopy;
+			monitor.beginTask("Corrected factory in: " + getPackageMemberName(unit), 0);
+		}
+	}
+	
+}

--- a/src/main/java/jce/generators/EcoreFactoryGenerator.xtend
+++ b/src/main/java/jce/generators/EcoreFactoryGenerator.xtend
@@ -2,8 +2,6 @@ package jce.generators
 
 import eme.generator.GeneratedEcoreMetamodel
 import java.io.File
-import java.util.LinkedList
-import java.util.List
 import jce.properties.EcorificationProperties
 import jce.util.PathHelper
 import jce.util.ResourceRefresher
@@ -12,11 +10,12 @@ import org.apache.log4j.LogManager
 import org.apache.log4j.Logger
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.IProgressMonitor
-import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EPackage
 
 import static jce.properties.TextProperty.ECORE_PACKAGE
 import static jce.properties.TextProperty.SOURCE_FOLDER
+
+import static extension jce.util.EPackageUtil.*;
 
 /** 
  * Creates and manages custom EFactories. Every EFactory has an interface and an implementation class.
@@ -71,18 +70,4 @@ final class EcoreFactoryGenerator {
 		}
 	}
 
-	/**
-	 * Returns the list of names of all EClasses in an EPackage.
-	 */
-	def private List<String> getClassNames(EPackage ePackage) {
-		val classes = new LinkedList<String>()
-		for (eClassifier : ePackage.EClassifiers) { // for every classifier
-			if (eClassifier instanceof EClass) { // if is EClass
-				if (!eClassifier.interface && !eClassifier.abstract) { // if is not interface
-					classes.add(eClassifier.name) // store name
-				}
-			}
-		}
-		return classes
-	}
 }

--- a/src/main/java/jce/util/EPackageUtil.xtend
+++ b/src/main/java/jce/util/EPackageUtil.xtend
@@ -16,4 +16,29 @@ class EPackageUtil {
 		return ePackage.EClassifiers.filter(EClass).filter[!interface && !abstract].map[name].toList
 	}
 
+	/**
+	 * Returns the package with the given fully qualified name, starting from the given root {@link EPackage}.
+	 * 
+	 * @param rootPackage the root {@link EPackage} of a metamodel to start from
+	 * @param fullyQualifiedName the fully qualified name of the package to search for
+	 * @return the resolved {@link EPackage} or <code>null</code> if none was found
+	 */
+	def static EPackage findPackage(EPackage rootPackage, String fullyQualifiedName) {
+		val pathHelper = new PathHelper(".");
+		if (rootPackage.ESuperPackage !== null || rootPackage.name != pathHelper.getFirstSegment(fullyQualifiedName)) {
+			return null;
+		}
+		var relativeName = pathHelper.cutFirstSegment(fullyQualifiedName, false);
+		var currentPackage = rootPackage;
+		while (!relativeName.empty) {
+			val currentPackageName = pathHelper.getFirstSegment(relativeName);
+			currentPackage = currentPackage.ESubpackages.findFirst[name == currentPackageName];
+			if (currentPackage === null) {
+				return null;
+			}
+			relativeName = pathHelper.cutFirstSegment(relativeName, false);
+		}
+		return currentPackage; 
+	}
+	
 }

--- a/src/main/java/jce/util/EPackageUtil.xtend
+++ b/src/main/java/jce/util/EPackageUtil.xtend
@@ -1,0 +1,19 @@
+package jce.util
+
+import java.util.List
+import org.eclipse.emf.ecore.EPackage
+import org.eclipse.emf.ecore.EClass
+
+/**
+ * Utility methods to extract information from an {@link EPackage}.
+ * @author Heiko Klare
+ */
+class EPackageUtil {
+	/**
+	 * Returns the list of names of all non-abstract {@link EClass}es in an {@link EPackage}.
+	 */
+	def static List<String> getClassNames(EPackage ePackage) {
+		return ePackage.EClassifiers.filter(EClass).filter[!interface && !abstract].map[name].toList
+	}
+
+}

--- a/src/main/java/jce/util/PathHelper.java
+++ b/src/main/java/jce/util/PathHelper.java
@@ -45,13 +45,25 @@ public class PathHelper {
     /**
      * Cuts the first segment of a path.
      * @param path is the path.
+     * @param keepSingleSegment specifies whether the path shall be preserved if only one segment is present
+     * @return the path without the first segment, or the original if it has no parents and keepSingleSegment is <code>true</code>.
+     */
+    public String cutFirstSegment(String path, boolean keepSingleSegment) {
+        if (path.contains(separatorString)) {
+            return path.substring(path.indexOf(separator) + 1);
+        } else if (!keepSingleSegment) {
+            return "";
+        }
+        return path;
+    }
+
+    /**
+     * Cuts the first segment of a path.
+     * @param path is the path.
      * @return the path without the first segment, or the original if it has no parents.
      */
     public String cutFirstSegment(String path) {
-        if (path.contains(separatorString)) {
-            return path.substring(path.indexOf(separator) + 1);
-        }
-        return path;
+        return cutFirstSegment(path, true);
     }
 
     /**


### PR DESCRIPTION
This pull request adds functionality to correctly update the `*Package` interface and `*PackageImpl` class of each `EPackage` to use the appropriate factory. As originally generated factories are replaced by new ones instantiating the original classes for those `EPackages` that have at least one non-abstract class, the package interface and class also has to use and deliver this newly generated factory.